### PR TITLE
Remove gerrit (gitreview) hook

### DIFF
--- a/.gitreview
+++ b/.gitreview
@@ -1,4 +1,0 @@
-[gerrit]
-host=review.openstack.org
-port=29418
-project=stackforge/clouddocs-maven-plugin.git


### PR DESCRIPTION
This repository is not managed through the stackforge, so this configuration file is not necessary.